### PR TITLE
Add extraArgs input for custom Monkey C compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This action build your ConnectIQ app
 
 **Required** The path where to export to. Default `"./out/export.prg"`.
 
+## `extraArgs`
+
+**Optional** Additional arguments passed to the monkeybrains compiler. Default `""`.
+
 ## Outputs
 
 (none)
@@ -57,6 +61,7 @@ jobs:
           outputPath: out/app.prg
           device: fr165
           typeCheck: '1'
+          extraArgs: '-z resources'
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Output path of the export'
     required: true
     default: './out/export.prg'
+  extraArgs:
+    description: 'Additional arguments passed to monkeybrains compiler'
+    required: false
+    default: ''
 outputs: {}
 runs:
   using: 'docker'
@@ -31,6 +35,7 @@ runs:
     - ${{ inputs.developerKey }}
     - ${{ inputs.outputPath }}
     - ${{ inputs.typeCheck }}
+    - ${{ inputs.extraArgs }}
 branding:
   icon: 'triangle'
   color: 'blue'

--- a/gen/README.md
+++ b/gen/README.md
@@ -24,6 +24,10 @@ This action build your ConnectIQ app
 
 **Required** The path where to export to. Default `"./out/export.prg"`.
 
+## `extraArgs`
+
+**Optional** Additional arguments passed to the monkeybrains compiler. Default `""`.
+
 ## Outputs
 
 (none)
@@ -57,6 +61,7 @@ jobs:
           outputPath: out/app.prg
           device: fr165
           typeCheck: '1'
+          extraArgs: '-z resources'
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/test.sh
+++ b/test.sh
@@ -5,13 +5,20 @@ DEVICE=$2
 DEVELOPER_KEY=$3
 OUTPUT=$4
 TYPE_CHECK=$5
+EXTRA_ARGS=$6
 
-mkdir -p $(dirname $OUTPUT)
+mkdir -p "$(dirname "$OUTPUT")"
 
-java \
+set -- \
     -jar /connectiq/bin/monkeybrains.jar \
-    -d $DEVICE \
-    -o $OUTPUT \
-    -f $PROJECT \
-    -y $DEVELOPER_KEY \
-    -w -l $TYPE_CHECK
+    -d "$DEVICE" \
+    -o "$OUTPUT" \
+    -f "$PROJECT" \
+    -y "$DEVELOPER_KEY" \
+    -w -l "$TYPE_CHECK"
+
+if [ -n "$EXTRA_ARGS" ]; then
+    set -- "$@" $EXTRA_ARGS
+fi
+
+java "$@"


### PR DESCRIPTION
This pull request adds support for passing extra arguments to the Monkeybrains compiler in the GitHub Action, making the action more flexible for advanced use cases. The changes update the action's input schema, documentation, and script to accept and handle an optional `extraArgs` parameter.

**Input and Argument Handling Enhancements:**

* Added a new optional `extraArgs` input to `action.yml`, allowing users to specify additional arguments for the Monkeybrains compiler. This input is now passed through the action to the build script. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R24-R27) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R38)
* Updated `test.sh` to accept and conditionally append the `EXTRA_ARGS` variable to the compiler command if provided, ensuring the extra arguments are used during the build process.

**Documentation Updates:**

* Updated `README.md` and `gen/README.md` to document the new `extraArgs` input, including usage examples in workflow YAML snippets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64) [[3]](diffhunk://#diff-1ced5825553324982b25b809e575c086bc679b2cfcfcd9fd002348c887b044d1R27-R30) [[4]](diffhunk://#diff-1ced5825553324982b25b809e575c086bc679b2cfcfcd9fd002348c887b044d1R64)